### PR TITLE
Adding Serialize derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Deriving `Serialize` for `IIR` and `IIR (int)` to support miniconf updates.
+
 ### Changed
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/idsp"
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
 num-complex = { version = "0.4.0", features = ["serde"], default-features = false }
-miniconf = "0.2"
+miniconf = "0.3"
 num-traits = { version = "0.2.14", features = ["libm"], default-features = false}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/idsp"
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
 num-complex = { version = "0.4.0", features = ["serde"], default-features = false }
-miniconf = { version = "0.2.0", optional = false }
+miniconf = "0.2"
 num-traits = { version = "0.2.14", features = ["libm"], default-features = false}
 
 [dev-dependencies]

--- a/src/iir.rs
+++ b/src/iir.rs
@@ -1,5 +1,5 @@
 use miniconf::MiniconfAtomic;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{abs, copysign, macc};
 use core::iter::Sum;
@@ -55,7 +55,7 @@ pub type Vec5<T> = [T; 5];
 /// new output is computed as `y0 = a1*y1 + a2*y2 + b0*x0 + b1*x1 + b2*x2`.
 /// The IIR coefficients can be mapped to other transfer function
 /// representations, for example as described in <https://arxiv.org/abs/1508.06319>
-#[derive(Copy, Clone, Debug, Default, Deserialize, MiniconfAtomic)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, MiniconfAtomic)]
 pub struct IIR<T> {
     pub ba: Vec5<T>,
     pub y_offset: T,

--- a/src/iir_int.rs
+++ b/src/iir_int.rs
@@ -1,7 +1,7 @@
 use super::tools::macc_i32;
 use core::f64::consts::PI;
 use miniconf::MiniconfAtomic;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Generic vector for integer IIR filter.
 /// This struct is used to hold the x/y input/output data vector or the b/a coefficient
@@ -46,7 +46,7 @@ impl Coeff for Vec5 {
 /// See `dsp::iir::IIR` for general implementation details.
 /// Offset and limiting disabled to suit lowpass applications.
 /// Coefficient scaling fixed and optimized.
-#[derive(Copy, Clone, Default, Debug, MiniconfAtomic, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, MiniconfAtomic, Serialize, Deserialize)]
 pub struct IIR {
     pub ba: Vec5,
     pub y_offset: i32,


### PR DESCRIPTION
This PR updates the structs that derive `MiniconfAtomic` to also derive `Serialize` in preparation for miniconf 0.3's release.