### PR TITLE
Bumping Miniconf version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+* Miniconf dependency bumped to 0.4
+
 ### Removed
 
 ## [0.7.1] - 2022-01-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/idsp"
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
 num-complex = { version = "0.4.0", features = ["serde"], default-features = false }
-miniconf = "0.3"
+miniconf = "0.4"
 num-traits = { version = "0.2.14", features = ["libm"], default-features = false}
 
 [dev-dependencies]


### PR DESCRIPTION
This PR bumps `idsp` to utilize miniconf 0.4 to provide support for the newest library reivision.

The Miniconf trait minorly changed