### PR TITLE
Upgrading miniconf version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-* Miniconf dependency bumped to 0.4
+* Miniconf dependency bumped to 0.5
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/idsp"
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
 num-complex = { version = "0.4.0", features = ["serde"], default-features = false }
-miniconf = "0.4"
+miniconf = "0.5"
 num-traits = { version = "0.2.14", features = ["libm"], default-features = false}
 
 [dev-dependencies]


### PR DESCRIPTION
This PR bumps miniconf up to 0.5.0 to address some issues with the previous trait API.