### PR TITLE
dsp-fixedpoint: adjust default features

### DIFF
--- a/dsp-fixedpoint/Cargo.toml
+++ b/dsp-fixedpoint/Cargo.toml
@@ -8,11 +8,15 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["serde"]
 std = []
+serde = ["dep:serde"]
 
 [dependencies]
-num-traits.workspace = true
-serde = { version = "1.0.228", default-features = false, features = ["derive"] }
+num-traits = { workspace = true, default-features = false }
+serde = { version = "1.0.228", default-features = false, features = [
+    "derive",
+], optional = true }
 
 [lints]
 workspace = true

--- a/dsp-fixedpoint/src/lib.rs
+++ b/dsp-fixedpoint/src/lib.rs
@@ -95,9 +95,10 @@ pub trait Accu<A> {
 /// assert_eq!(7 * Q8::<4>::from_f32(1.5), 10);
 /// assert_eq!(7 / Q8::<4>::from_f32(1.5), 4);
 /// ```
-#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default)]
 #[repr(transparent)]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Q<T, A, const F: i8> {
     /// The accumulator type
     _accu: PhantomData<A>,


### PR DESCRIPTION
allows including this as a typing dependency without requiring serde and libm.